### PR TITLE
QAA-5063: MOB2 doesn't count as a valid JIRA value in PR title

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - name: Verify PR Title Contains a JIRA
         if: ${{ ! contains( github.event.pull_request.labels.*.name, 'SKIP PR VALIDATION') }}
-        run: echo "${{ github.event.pull_request.title }}" | grep -Pq '^[a-zA-Z]{2,10}-[0-9]{1,10}( |:|-|,).+'
+        run: echo "${{ github.event.pull_request.title }}" | grep -Pq '^[a-zA-Z0-9]{2,10}-[0-9]{1,10}( |:|-|,).+'


### PR DESCRIPTION
e.g. MOB2: https://bluescape.slack.com/archives/CGZHGNMRR/p1647383004562759