### PR TITLE
QAA-5216: Switch validate PR to node shell to support ' character

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -12,4 +12,10 @@ jobs:
     steps:
       - name: Verify that the PR title starts with a JIRA
         if: ${{ ! contains( github.event.pull_request.labels.*.name, 'SKIP PR VALIDATION') }}
-        run: echo '${{ github.event.pull_request.title }}' | grep -Pq '^(Revert \")*[a-zA-Z0-9]{2,10}-[0-9]{1,10}( |:|-|,).+'
+        run: |
+          const fs = require('fs');
+          const eventData = JSON.parse(fs.readFileSync('${{github.event_path}}', {encoding: 'utf8', flag: 'r'}));
+          if (!/^(Revert \")*[a-zA-Z0-9]{2,10}-[0-9]{1,10}( |:|-|,).+/.test(eventData.pull_request.title)) {
+            process.exit(1);
+          }
+        shell: node {0}

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Verify that the PR title starts with a JIRA
         if: ${{ ! contains( github.event.pull_request.labels.*.name, 'SKIP PR VALIDATION') }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          const fs = require('fs');
-          const eventData = JSON.parse(fs.readFileSync('${{github.event_path}}', {encoding: 'utf8', flag: 'r'}));
-          if (!/^(Revert \")*[a-zA-Z0-9]{2,10}-[0-9]{1,10}( |:|-|,).+/.test(eventData.pull_request.title)) {
+          if (!/^(Revert \")*[a-zA-Z0-9]{2,10}-[0-9]{1,10}( |:|-|,).+/.test(process.env.PR_TITLE)) {
             process.exit(1);
           }
         shell: node {0}


### PR DESCRIPTION
When validating the PR title, GitHub actions does not seem to
provide a way to escape any quotes for shell usage, so titles
with quotes just fail.
If we store it as an environment variable and then parse that, it works. (Thanks Landon!)