### PR TITLE
Add tests for validate_pr workflow

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -2,6 +2,11 @@ name: Validate PR
 
 on:
   workflow_call:
+    inputs:
+      title:
+        description: Title
+        required: false
+        type: string
   pull_request:
     types: [opened, synchronize, edited]
 
@@ -9,13 +14,16 @@ jobs:
   title_check:
     name: Title Validation
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && ! contains( github.event.pull_request.labels.*.name, 'SKIP PR VALIDATION')
     steps:
       - name: Verify that the PR title starts with a JIRA
-        if: ${{ ! contains( github.event.pull_request.labels.*.name, 'SKIP PR VALIDATION') }}
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_TITLE: ${{ inputs.title || github.event.pull_request.title }}
         run: |
           if (!/^(Revert \")*[a-zA-Z0-9]{2,10}-[0-9]{1,10}( |:|-|,).+/.test(process.env.PR_TITLE)) {
+            console.error('PR Title does not match regex pattern!\nPlease follow format: "<JIRA_PROJ>-<JIRA_NUM>: <TITLE>"\nExample: "JIRA-404: Title Here"');
             process.exit(1);
+          } else {
+            console.log('Title passed validation!')
           }
         shell: node {0}

--- a/.github/workflows/validate_pr_test.yml
+++ b/.github/workflows/validate_pr_test.yml
@@ -1,0 +1,35 @@
+name: Test Validate PR
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/validate_pr.yml
+      - .github/workflows/validate_pr_test.yml
+
+jobs:
+  with_space:
+    name: With Space - Expect Pass
+    uses: ./.github/workflows/validate_pr.yml
+    with:
+      title: "JIRA-007 Title here"
+  with_colon:
+    name: With Colon - Expect Pass
+    uses: ./.github/workflows/validate_pr.yml
+    with:
+      title: "JIRA-007: Title here"
+  with_no_title:
+    name: With No Title - Expect Fail
+    uses: ./.github/workflows/validate_pr.yml
+    with:
+      title: "JIRA-007"
+  verify_negative_tests:
+    needs: [with_no_title]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Validate test status
+        run: |
+          if [ "${{ needs.with_no_title.result }}" != "failure" ]; then
+            echo "No Title Passed when it shouldn't"
+            exit 1
+          fi

--- a/.github/workflows/validate_pr_test.yml
+++ b/.github/workflows/validate_pr_test.yml
@@ -17,6 +17,11 @@ jobs:
     uses: ./.github/workflows/validate_pr.yml
     with:
       title: "JIRA-007: Title here"
+  on_revert:
+    name: On Revert - Expect Pass
+    uses: ./.github/workflows/validate_pr.yml
+    with:
+      title: "Revert \"JIRA-007: Title her\""
   with_no_title:
     name: With No Title - Expect Fail
     uses: ./.github/workflows/validate_pr.yml


### PR DESCRIPTION
Some validation of the validate_pr workflow while developing it to set expectations. Also improved logging when the validation passes and fails.

Example error logging: 
```
PR Title does not match regex pattern!
Please follow format: "<JIRA_PROJ>-<JIRA_NUM>: <TITLE>"
Example: "JIRA-404: Title Here"
```